### PR TITLE
feat: YgentsConfig#llmをlitellmにリファクタリング

### DIFF
--- a/examples/agent_with_mcp.py
+++ b/examples/agent_with_mcp.py
@@ -47,7 +47,7 @@ from ygents.agent.models import (
     ToolInput,
     ToolResult,
 )
-from ygents.config.models import LLMConfig, OpenAIConfig, YgentsConfig
+from ygents.config.models import YgentsConfig
 
 
 def create_inmemory_mcp_config():
@@ -119,16 +119,14 @@ async def mcp_agent_example():
 
     # 設定を作成（MCPサーバーあり）
     config = YgentsConfig(
-        llm=LLMConfig(
-            provider="openai",
-            openai=OpenAIConfig(
-                api_key=os.getenv("OPENAI_API_KEY", ""), model="gpt-4o"
-            ),
-        ),
+        litellm={
+            "model": "openai/gpt-4o",
+            "api_key": os.getenv("OPENAI_API_KEY", "")
+        },
     )
 
     # APIキーの確認
-    if not config.llm.openai.api_key:
+    if not config.litellm.get("api_key"):
         print("❌ エラー: OPENAI_API_KEYが設定されていません")
         print("以下のコマンドでAPIキーを設定してください:")
         print("export OPENAI_API_KEY='your-openai-api-key'")
@@ -210,16 +208,14 @@ async def interactive_mcp_chat():
 
     # 設定を作成
     config = YgentsConfig(
-        llm=LLMConfig(
-            provider="openai",
-            openai=OpenAIConfig(
-                api_key=os.getenv("OPENAI_API_KEY", ""), model="gpt-4o"
-            ),
-        ),
+        litellm={
+            "model": "openai/gpt-4o",
+            "api_key": os.getenv("OPENAI_API_KEY", "")
+        },
         mcp_servers={"example_server": {}},
     )
 
-    if not config.llm.openai.api_key:
+    if not config.litellm.get("api_key"):
         print("❌ エラー: OPENAI_API_KEYが設定されていません")
         return
 

--- a/examples/simple_agent.py
+++ b/examples/simple_agent.py
@@ -38,7 +38,7 @@ sys.path.insert(0, str(project_root / "src"))
 
 from ygents.agent.core import Agent
 from ygents.agent.models import ContentChunk, ErrorMessage, StatusUpdate
-from ygents.config.models import LLMConfig, OpenAIConfig, YgentsConfig
+from ygents.config.models import YgentsConfig
 
 
 async def simple_chat_example():
@@ -48,17 +48,15 @@ async def simple_chat_example():
 
     # 設定を作成
     config = YgentsConfig(
-        llm=LLMConfig(
-            provider="openai",
-            openai=OpenAIConfig(
-                api_key=os.getenv("OPENAI_API_KEY", ""), model="gpt-4o"
-            ),
-        ),
+        litellm={
+            "model": "openai/gpt-4o",
+            "api_key": os.getenv("OPENAI_API_KEY", "")
+        },
         mcp_servers={},  # MCPサーバーなしで実行
     )
 
     # APIキーの確認
-    if not config.llm.openai.api_key:
+    if not config.litellm.get("api_key"):
         print("❌ エラー: OPENAI_API_KEYが設定されていません")
         print("以下のコマンドでAPIキーを設定してください:")
         print("export OPENAI_API_KEY='your-openai-api-key'")
@@ -102,16 +100,14 @@ async def interactive_chat():
 
     # 設定を作成
     config = YgentsConfig(
-        llm=LLMConfig(
-            provider="openai",
-            openai=OpenAIConfig(
-                api_key=os.getenv("OPENAI_API_KEY", ""), model="gpt-3.5-turbo"
-            ),
-        ),
+        litellm={
+            "model": "openai/gpt-3.5-turbo",
+            "api_key": os.getenv("OPENAI_API_KEY", "")
+        },
         mcp_servers={},
     )
 
-    if not config.llm.openai.api_key:
+    if not config.litellm.get("api_key"):
         print("❌ エラー: OPENAI_API_KEYが設定されていません")
         return
 

--- a/src/ygents/agent/core.py
+++ b/src/ygents/agent/core.py
@@ -121,11 +121,10 @@ class Agent:
             )
 
             response = litellm.completion(
-                model=self._get_model_name(),
                 messages=messages_dict,
                 tools=tools_schema,
                 stream=True,
-                **self._get_llm_params(),
+                **self.config.litellm,
             )
 
             assistant_message = Message(role="assistant", content="", tool_calls=[])
@@ -276,32 +275,6 @@ class Agent:
             return any(keyword in content for keyword in end_keywords)
         return False
 
-    def _get_model_name(self) -> str:
-        """設定からモデル名を取得"""
-        provider = self.config.llm.provider
-
-        if provider == "openai" and self.config.llm.openai:
-            return self.config.llm.openai.model
-        elif provider == "claude" and self.config.llm.claude:
-            return self.config.llm.claude.model
-        else:
-            raise ValueError(f"Unsupported provider: {provider}")
-
-    def _get_llm_params(self) -> Dict[str, Any]:
-        """LiteLLM呼び出しパラメータを生成"""
-        params: Dict[str, Any] = {
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        }
-
-        provider = self.config.llm.provider
-
-        if provider == "openai" and self.config.llm.openai:
-            params["api_key"] = self.config.llm.openai.api_key
-        elif provider == "claude" and self.config.llm.claude:
-            params["api_key"] = self.config.llm.claude.api_key
-
-        return params
 
     def _get_tools_schema(self) -> List[Dict[str, Any]]:
         """MCPツールをLiteLLM tools形式に変換"""

--- a/src/ygents/config/__init__.py
+++ b/src/ygents/config/__init__.py
@@ -1,17 +1,9 @@
 """Configuration management module."""
 
 from .loader import ConfigLoader
-from .models import (
-    ClaudeConfig,
-    LLMConfig,
-    OpenAIConfig,
-    YgentsConfig,
-)
+from .models import YgentsConfig
 
 __all__ = [
     "ConfigLoader",
     "YgentsConfig",
-    "LLMConfig",
-    "OpenAIConfig",
-    "ClaudeConfig",
 ]

--- a/src/ygents/config/loader.py
+++ b/src/ygents/config/loader.py
@@ -99,19 +99,15 @@ class ConfigLoader:
         # Handle OpenAI API key override
         openai_key = os.getenv("OPENAI_API_KEY")
         if openai_key:
-            if "llm" not in config:
-                config["llm"] = {}
-            if "openai" not in config["llm"]:
-                config["llm"]["openai"] = {}
-            config["llm"]["openai"]["api_key"] = openai_key
+            if "litellm" not in config:
+                config["litellm"] = {}
+            config["litellm"]["api_key"] = openai_key
 
-        # Handle Claude API key override
+        # Handle Claude API key override (Anthropic)
         claude_key = os.getenv("ANTHROPIC_API_KEY")
         if claude_key:
-            if "llm" not in config:
-                config["llm"] = {}
-            if "claude" not in config["llm"]:
-                config["llm"]["claude"] = {}
-            config["llm"]["claude"]["api_key"] = claude_key
+            if "litellm" not in config:
+                config["litellm"] = {}
+            config["litellm"]["api_key"] = claude_key
 
         return config

--- a/src/ygents/config/models.py
+++ b/src/ygents/config/models.py
@@ -1,43 +1,12 @@
 """Configuration data models."""
 
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict
 
-from pydantic import BaseModel, Field, model_validator
-
-
-class OpenAIConfig(BaseModel):
-    """OpenAI configuration."""
-
-    api_key: str
-    model: str = "gpt-3.5-turbo"
-
-
-class ClaudeConfig(BaseModel):
-    """Claude configuration."""
-
-    api_key: str
-    model: str = "claude-3-sonnet-20240229"
-
-
-class LLMConfig(BaseModel):
-    """LLM configuration."""
-
-    provider: Literal["openai", "claude"]
-    openai: Optional[OpenAIConfig] = None
-    claude: Optional[ClaudeConfig] = None
-
-    @model_validator(mode="after")
-    def validate_provider_config(self) -> "LLMConfig":
-        """Validate that provider configuration is present."""
-        if self.provider == "openai" and self.openai is None:
-            raise ValueError("Provider configuration is required for OpenAI")
-        if self.provider == "claude" and self.claude is None:
-            raise ValueError("Provider configuration is required for Claude")
-        return self
+from pydantic import BaseModel, Field
 
 
 class YgentsConfig(BaseModel):
     """Main ygents configuration."""
 
     mcp_servers: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
-    llm: LLMConfig
+    litellm: Dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_config/test_loader.py
+++ b/tests/test_config/test_loader.py
@@ -22,11 +22,9 @@ mcpServers:
     command: "python"
     args: ["./assistant_server.py"]
 
-llm:
-  provider: "openai"
-  openai:
-    api_key: "test-openai-key"
-    model: "gpt-3.5-turbo"
+litellm:
+  model: "openai/gpt-3.5-turbo"
+  api_key: "test-openai-key"
 """
         config_file.write_text(config_content)
 
@@ -40,18 +38,16 @@ llm:
             == "https://weather-api.example.com/mcp"
         )
         assert config.mcp_servers["assistant"]["command"] == "python"
-        assert config.llm.provider == "openai"
-        assert config.llm.openai.api_key == "test-openai-key"
+        assert config.litellm["model"] == "openai/gpt-3.5-turbo"
+        assert config.litellm["api_key"] == "test-openai-key"
 
     def test_load_yaml_config_with_environment_override(self, temp_dir):
         """Test YAML config with environment variable override."""
         config_file = temp_dir / "config.yaml"
         config_content = """
-llm:
-  provider: "openai"
-  openai:
-    api_key: "placeholder"
-    model: "gpt-3.5-turbo"
+litellm:
+  model: "openai/gpt-3.5-turbo"
+  api_key: "placeholder"
 """
         config_file.write_text(config_content)
 
@@ -63,7 +59,7 @@ llm:
             config = loader.load_from_file(str(config_file))
 
             # Environment variable should override YAML value
-            assert config.llm.openai.api_key == "env-openai-key"
+            assert config.litellm["api_key"] == "env-openai-key"
         finally:
             # Clean up environment variable
             os.environ.pop("OPENAI_API_KEY", None)
@@ -72,48 +68,46 @@ llm:
         """Test YAML config with Claude provider."""
         config_file = temp_dir / "config.yaml"
         config_content = """
-llm:
-  provider: "claude"
-  claude:
-    api_key: "test-claude-key"
-    model: "claude-3-sonnet-20240229"
+litellm:
+  model: "anthropic/claude-3-sonnet-20240229"
+  api_key: "test-claude-key"
 """
         config_file.write_text(config_content)
 
         loader = ConfigLoader()
         config = loader.load_from_file(str(config_file))
 
-        assert config.llm.provider == "claude"
-        assert config.llm.claude.api_key == "test-claude-key"
-        assert config.llm.claude.model == "claude-3-sonnet-20240229"
+        assert config.litellm["model"] == "anthropic/claude-3-sonnet-20240229"
+        assert config.litellm["api_key"] == "test-claude-key"
 
-    def test_config_validation_missing_required_fields(self, temp_dir):
-        """Test config validation with missing LLM config."""
+    def test_config_validation_empty_config(self, temp_dir):
+        """Test config validation with empty config (should not fail)."""
         config_file = temp_dir / "config.yaml"
         config_content = """
 mcpServers:
   weather:
     url: "https://weather-api.example.com/mcp"
-# Missing required llm section
+# litellm is optional now
 """
         config_file.write_text(config_content)
 
         loader = ConfigLoader()
-        with pytest.raises(ValueError, match="validation error"):
-            loader.load_from_file(str(config_file))
+        config = loader.load_from_file(str(config_file))
+        assert config.litellm == {}
 
-    def test_config_validation_invalid_provider(self, temp_dir):
-        """Test config validation with invalid LLM provider."""
+    def test_config_validation_invalid_litellm_config(self, temp_dir):
+        """Test config validation with invalid litellm config."""
         config_file = temp_dir / "config.yaml"
         config_content = """
-llm:
-  provider: "invalid_provider"
+litellm:
+  invalid_field: "invalid_value"
 """
         config_file.write_text(config_content)
 
         loader = ConfigLoader()
-        with pytest.raises(ValueError, match="validation error"):
-            loader.load_from_file(str(config_file))
+        # Should not fail - litellm accepts any dict
+        config = loader.load_from_file(str(config_file))
+        assert config.litellm["invalid_field"] == "invalid_value"
 
     def test_load_nonexistent_config_file(self):
         """Test loading non-existent config file raises appropriate error."""
@@ -139,27 +133,26 @@ invalid: yaml: content:
         """Test that default values are properly applied."""
         config_file = temp_dir / "config.yaml"
         config_content = """
-llm:
-  provider: "openai"
-  openai:
-    api_key: "test-key"
-    # model not specified - should use default
+litellm:
+  api_key: "test-key"
+  # model not specified - should be handled by litellm
 """
         config_file.write_text(config_content)
 
         loader = ConfigLoader()
         config = loader.load_from_file(str(config_file))
 
-        # Default model should be applied
-        assert config.llm.openai.model == "gpt-3.5-turbo"
+        # Only api_key should be present
+        assert config.litellm["api_key"] == "test-key"
+        assert "model" not in config.litellm
 
     def test_load_from_dict(self, clean_env):
         """Test loading config from dictionary."""
         config_dict = {
             "mcpServers": {"test": {"command": "python", "args": ["test.py"]}},
-            "llm": {
-                "provider": "openai",
-                "openai": {"api_key": "test-key", "model": "gpt-4"},
+            "litellm": {
+                "model": "openai/gpt-4",
+                "api_key": "test-key",
             },
         }
 
@@ -168,4 +161,4 @@ llm:
 
         assert isinstance(config, YgentsConfig)
         assert config.mcp_servers["test"]["command"] == "python"
-        assert config.llm.openai.model == "gpt-4"
+        assert config.litellm["model"] == "openai/gpt-4"

--- a/tests/test_config/test_models.py
+++ b/tests/test_config/test_models.py
@@ -3,84 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ygents.config.models import (
-    ClaudeConfig,
-    LLMConfig,
-    OpenAIConfig,
-    YgentsConfig,
-)
-
-
-class TestOpenAIConfig:
-    """Test cases for OpenAIConfig."""
-
-    def test_openai_config_basic(self):
-        """Test basic OpenAI config."""
-        config = OpenAIConfig(api_key="test-key")
-        assert config.api_key == "test-key"
-        assert config.model == "gpt-3.5-turbo"  # default value
-
-    def test_openai_config_with_custom_model(self):
-        """Test OpenAI config with custom model."""
-        config = OpenAIConfig(api_key="test-key", model="gpt-4")
-        assert config.api_key == "test-key"
-        assert config.model == "gpt-4"
-
-    def test_openai_config_validation_missing_api_key(self):
-        """Test validation error when API key is missing."""
-        with pytest.raises(ValidationError, match="api_key"):
-            OpenAIConfig()
-
-
-class TestClaudeConfig:
-    """Test cases for ClaudeConfig."""
-
-    def test_claude_config_basic(self):
-        """Test basic Claude config."""
-        config = ClaudeConfig(api_key="test-key")
-        assert config.api_key == "test-key"
-        assert config.model == "claude-3-sonnet-20240229"  # default value
-
-    def test_claude_config_with_custom_model(self):
-        """Test Claude config with custom model."""
-        config = ClaudeConfig(api_key="test-key", model="claude-3-opus-20240229")
-        assert config.api_key == "test-key"
-        assert config.model == "claude-3-opus-20240229"
-
-    def test_claude_config_validation_missing_api_key(self):
-        """Test validation error when API key is missing."""
-        with pytest.raises(ValidationError, match="api_key"):
-            ClaudeConfig()
-
-
-class TestLLMConfig:
-    """Test cases for LLMConfig."""
-
-    def test_llm_config_openai(self):
-        """Test LLM config with OpenAI provider."""
-        config = LLMConfig(provider="openai", openai=OpenAIConfig(api_key="test-key"))
-        assert config.provider == "openai"
-        assert config.openai.api_key == "test-key"
-        assert config.claude is None
-
-    def test_llm_config_claude(self):
-        """Test LLM config with Claude provider."""
-        config = LLMConfig(provider="claude", claude=ClaudeConfig(api_key="test-key"))
-        assert config.provider == "claude"
-        assert config.claude.api_key == "test-key"
-        assert config.openai is None
-
-    def test_llm_config_validation_invalid_provider(self):
-        """Test validation error with invalid provider."""
-        with pytest.raises(
-            ValidationError, match="Input should be 'openai' or 'claude'"
-        ):
-            LLMConfig(provider="invalid")
-
-    def test_llm_config_validation_missing_provider_config(self):
-        """Test validation error when provider config is missing."""
-        with pytest.raises(ValidationError, match="Provider configuration is required"):
-            LLMConfig(provider="openai")
+from ygents.config.models import YgentsConfig
 
 
 class TestYgentsConfig:
@@ -88,11 +11,22 @@ class TestYgentsConfig:
 
     def test_ygents_config_minimal(self):
         """Test minimal Ygents config."""
-        config = YgentsConfig(
-            llm=LLMConfig(provider="openai", openai=OpenAIConfig(api_key="test-key"))
-        )
+        config = YgentsConfig()
         assert config.mcp_servers == {}
-        assert config.llm.provider == "openai"
+        assert config.litellm == {}
+
+    def test_ygents_config_with_litellm(self):
+        """Test Ygents config with litellm configuration."""
+        config = YgentsConfig(
+            litellm={
+                "model": "gpt-3.5-turbo",
+                "api_key": "test-key",
+                "temperature": 0.7
+            }
+        )
+        assert config.litellm["model"] == "gpt-3.5-turbo"
+        assert config.litellm["api_key"] == "test-key"
+        assert config.litellm["temperature"] == 0.7
 
     def test_ygents_config_with_mcp_servers(self):
         """Test Ygents config with MCP servers (raw dict format)."""
@@ -101,14 +35,12 @@ class TestYgentsConfig:
                 "weather": {"url": "https://weather.example.com"},
                 "assistant": {"command": "python", "args": ["server.py"]},
             },
-            llm=LLMConfig(provider="claude", claude=ClaudeConfig(api_key="test-key")),
+            litellm={
+                "model": "claude-3-sonnet-20240229",
+                "api_key": "test-key"
+            }
         )
         assert len(config.mcp_servers) == 2
         assert config.mcp_servers["weather"]["url"] == "https://weather.example.com"
         assert config.mcp_servers["assistant"]["command"] == "python"
-        assert config.llm.provider == "claude"
-
-    def test_ygents_config_validation_missing_llm(self):
-        """Test validation error when LLM config is missing."""
-        with pytest.raises(ValidationError, match="llm"):
-            YgentsConfig()
+        assert config.litellm["model"] == "claude-3-sonnet-20240229"


### PR DESCRIPTION
## Summary
- YgentsConfig.llmフィールドをlitellm: Dict[str, Any]に変更
- OpenAIConfig、ClaudeConfig、LLMConfigクラスを削除してシンプル化
- Agent.coreでlitellm設定を直接パススルーするように変更

## Changes
### Configuration Models
- `YgentsConfig.llm`を`YgentsConfig.litellm: Dict[str, Any]`に変更
- 古いプロバイダー固有の設定クラス（OpenAIConfig、ClaudeConfig、LLMConfig）を削除

### Agent Core
- `_get_model_name()`と`_get_llm_params()`メソッドを削除
- `litellm.completion()`に設定を直接パススルー

### Examples & Tests
- examples/内のファイルを新しい設定形式に更新
- テストケースを新しい形式に合わせて更新

## Benefits
- litellmの柔軟な設定形式を直接利用可能
- プロバイダー固有の設定クラスの維持が不要
- より簡潔で保守しやすいコード

## Test plan
- [x] 設定モデルのテストが通過することを確認
- [x] ConfigLoaderのテストが通過することを確認
- [x] 基本的な機能が動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)