### PR TITLE
feat: SystemPromptConfig設定モデルを実装

### DIFF
--- a/src/ygents/config/models.py
+++ b/src/ygents/config/models.py
@@ -1,8 +1,28 @@
 """Configuration data models."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
+
+
+class SystemPromptConfig(BaseModel):
+    """システムプロンプト設定."""
+
+    # プロンプトタイプの指定
+    type: str = Field(
+        default="default",
+        description="プロンプトタイプ (default, react, analytical, etc.)",
+    )
+
+    # カスタムプロンプト（typeより優先）
+    custom_prompt: Optional[str] = Field(
+        default=None, description="カスタムシステムプロンプト"
+    )
+
+    # プロンプト変数（テンプレート内で使用）
+    variables: Dict[str, str] = Field(
+        default_factory=dict, description="プロンプトテンプレート内で使用される変数"
+    )
 
 
 class YgentsConfig(BaseModel):

--- a/tests/test_config/test_models.py
+++ b/tests/test_config/test_models.py
@@ -1,6 +1,6 @@
 """Configuration models tests."""
 
-from ygents.config.models import YgentsConfig
+from ygents.config.models import SystemPromptConfig, YgentsConfig
 
 
 class TestYgentsConfig:
@@ -38,3 +38,64 @@ class TestYgentsConfig:
         assert config.mcp_servers["weather"]["url"] == "https://weather.example.com"
         assert config.mcp_servers["assistant"]["command"] == "python"
         assert config.litellm["model"] == "claude-3-sonnet-20240229"
+
+
+class TestSystemPromptConfig:
+    """Test cases for SystemPromptConfig."""
+
+    def test_system_prompt_config_minimal(self):
+        """Test minimal SystemPromptConfig with defaults."""
+        config = SystemPromptConfig()
+        assert config.type == "default"
+        assert config.custom_prompt is None
+        assert config.variables == {}
+
+    def test_system_prompt_config_with_type(self):
+        """Test SystemPromptConfig with specific type."""
+        config = SystemPromptConfig(type="react")
+        assert config.type == "react"
+        assert config.custom_prompt is None
+        assert config.variables == {}
+
+    def test_system_prompt_config_with_custom_prompt(self):
+        """Test SystemPromptConfig with custom prompt."""
+        custom_prompt = "あなたは{role}として、{task}を実行してください。"
+        config = SystemPromptConfig(custom_prompt=custom_prompt)
+        assert config.type == "default"  # デフォルト値
+        assert config.custom_prompt == custom_prompt
+        assert config.variables == {}
+
+    def test_system_prompt_config_with_variables(self):
+        """Test SystemPromptConfig with template variables."""
+        variables = {"domain": "データ分析", "expertise_level": "上級"}
+        config = SystemPromptConfig(type="react", variables=variables)
+        assert config.type == "react"
+        assert config.custom_prompt is None
+        assert config.variables == variables
+
+    def test_system_prompt_config_full(self):
+        """Test SystemPromptConfig with all fields."""
+        custom_prompt = "あなたは{role}として、{task}を実行してください。"
+        variables = {"role": "データサイエンティスト", "task": "統計分析"}
+        config = SystemPromptConfig(
+            type="custom", custom_prompt=custom_prompt, variables=variables
+        )
+        assert config.type == "custom"
+        assert config.custom_prompt == custom_prompt
+        assert config.variables == variables
+
+    def test_system_prompt_config_empty_variables(self):
+        """Test SystemPromptConfig with explicitly empty variables."""
+        config = SystemPromptConfig(type="react", variables={})
+        assert config.type == "react"
+        assert config.variables == {}
+
+    def test_system_prompt_config_field_types(self):
+        """Test SystemPromptConfig field types."""
+        config = SystemPromptConfig(
+            type="test", custom_prompt="test prompt", variables={"key": "value"}
+        )
+        assert isinstance(config.type, str)
+        assert isinstance(config.custom_prompt, str)
+        assert isinstance(config.variables, dict)
+        assert isinstance(config.variables["key"], str)


### PR DESCRIPTION
## 概要

システムプロンプト設定を管理するPydanticベースの設定モデルを実装しました。

## 実装内容

### SystemPromptConfigクラス
```python
class SystemPromptConfig(BaseModel):
    """システムプロンプト設定."""

    # プロンプトタイプの指定
    type: str = Field(
        default="default",
        description="プロンプトタイプ (default, react, analytical, etc.)",
    )

    # カスタムプロンプト（typeより優先）
    custom_prompt: Optional[str] = Field(
        default=None, description="カスタムシステムプロンプト"
    )

    # プロンプト変数（テンプレート内で使用）
    variables: Dict[str, str] = Field(
        default_factory=dict, description="プロンプトテンプレート内で使用される変数"
    )
```

### フィールド設計

#### 1. type フィールド
- **目的**: プロンプトテンプレートの種類を指定
- **デフォルト**: "default"
- **例**: "default", "react", "analytical", "creative"

#### 2. custom_prompt フィールド  
- **目的**: ユーザー独自のシステムプロンプト指定
- **デフォルト**: None (Optional)
- **優先度**: typeより高い（指定時はtypeより優先される）

#### 3. variables フィールド
- **目的**: プロンプトテンプレート内での変数置換
- **デフォルト**: 空辞書
- **型**: Dict[str, str]

### 包括的テスト追加

7個の新規テストケース：
- `test_system_prompt_config_minimal`: デフォルト値の確認
- `test_system_prompt_config_with_type`: 特定タイプの指定
- `test_system_prompt_config_with_custom_prompt`: カスタムプロンプト指定
- `test_system_prompt_config_with_variables`: テンプレート変数の使用
- `test_system_prompt_config_full`: 全フィールド指定
- `test_system_prompt_config_empty_variables`: 明示的な空変数
- `test_system_prompt_config_field_types`: フィールド型の確認

## テスト結果

```
10 passed in 0.63s (既存3個 + 新規7個)
型チェック: Success: no issues found
Lint: エラーなし
```

## 技術的特徴

1. **Pydanticバリデーション**: 型安全性とデータ検証
2. **適切なデフォルト値**: 直感的な初期設定
3. **詳細なdescription**: 各フィールドの用途を明確化
4. **TDD手法**: テストファーストで期待動作を定義

## 使用例

### 基本的な使用
```python
# デフォルト設定
config = SystemPromptConfig()
# type="default", custom_prompt=None, variables={}

# プロンプトタイプ指定
config = SystemPromptConfig(type="react")

# カスタムプロンプト使用
config = SystemPromptConfig(
    custom_prompt="あなたは{role}として{task}を行ってください。",
    variables={"role": "エンジニア", "task": "コード生成"}
)
```

### YAML設定での使用イメージ
```yaml
system_prompt:
  type: "react"
  variables:
    domain: "データ分析"
    expertise_level: "上級"

# または

system_prompt:
  custom_prompt: "あなたは{role}専門家です。"
  variables:
    role: "機械学習"
```

## 設計原則

1. **簡潔性**: 必要最小限のフィールド設計
2. **柔軟性**: type指定とcustom_prompt両方に対応
3. **拡張性**: 将来のプロンプトタイプ追加に対応
4. **型安全性**: Pydanticによる強力な型チェック

## 依存関係

この実装により以下が可能になります：
- Issue #29: YgentsConfigへのsystem_promptフィールド追加
- Issue #30: Agentクラスでのシステムプロンプト注入
- Issue #31: システムプロンプト取得と適用ロジック

## 関連

- Closes #28
- Part of システムプロンプト管理機能の実装
- 依存: Issue #25, #26 (完了済み)
- 設計書: `design/system-prompt-management.md`

🤖 Generated with [Claude Code](https://claude.ai/code)