### PR TITLE
feat: YgentsConfigにsystem_promptフィールドを追加

### DIFF
--- a/src/ygents/config/models.py
+++ b/src/ygents/config/models.py
@@ -30,3 +30,8 @@ class YgentsConfig(BaseModel):
 
     mcp_servers: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     litellm: Dict[str, Any] = Field(default_factory=dict)
+
+    # システムプロンプト設定
+    system_prompt: Optional[SystemPromptConfig] = Field(
+        default=None, description="システムプロンプトの設定"
+    )

--- a/tests/test_config/test_models.py
+++ b/tests/test_config/test_models.py
@@ -11,6 +11,7 @@ class TestYgentsConfig:
         config = YgentsConfig()
         assert config.mcp_servers == {}
         assert config.litellm == {}
+        assert config.system_prompt is None
 
     def test_ygents_config_with_litellm(self):
         """Test Ygents config with litellm configuration."""
@@ -38,6 +39,55 @@ class TestYgentsConfig:
         assert config.mcp_servers["weather"]["url"] == "https://weather.example.com"
         assert config.mcp_servers["assistant"]["command"] == "python"
         assert config.litellm["model"] == "claude-3-sonnet-20240229"
+
+    def test_ygents_config_with_system_prompt(self):
+        """Test YgentsConfig with system prompt configuration."""
+        system_prompt_config = SystemPromptConfig(type="react")
+        config = YgentsConfig(
+            litellm={"model": "openai/gpt-4o", "api_key": "test-key"},
+            system_prompt=system_prompt_config,
+        )
+        assert config.system_prompt is not None
+        assert config.system_prompt.type == "react"
+        assert config.system_prompt.custom_prompt is None
+        assert config.system_prompt.variables == {}
+
+    def test_ygents_config_with_system_prompt_dict(self):
+        """Test YgentsConfig with system prompt as dict."""
+        config = YgentsConfig(
+            system_prompt={
+                "type": "custom",
+                "custom_prompt": "あなたは{role}です。",
+                "variables": {"role": "エンジニア"},
+            }
+        )
+        assert config.system_prompt is not None
+        assert config.system_prompt.type == "custom"
+        assert config.system_prompt.custom_prompt == "あなたは{role}です。"
+        assert config.system_prompt.variables == {"role": "エンジニア"}
+
+    def test_ygents_config_full_configuration(self):
+        """Test YgentsConfig with all fields including system_prompt."""
+        config = YgentsConfig(
+            mcp_servers={"weather": {"url": "https://weather.example.com"}},
+            litellm={"model": "openai/gpt-4o", "api_key": "test-key"},
+            system_prompt={"type": "react", "variables": {"domain": "データ分析"}},
+        )
+        assert len(config.mcp_servers) == 1
+        assert config.litellm["model"] == "openai/gpt-4o"
+        assert config.system_prompt is not None
+        assert config.system_prompt.type == "react"
+        assert config.system_prompt.variables == {"domain": "データ分析"}
+
+    def test_ygents_config_backward_compatibility(self):
+        """Test that existing configurations without system_prompt still work."""
+        config = YgentsConfig(
+            mcp_servers={"test": {"url": "https://test.example.com"}},
+            litellm={"model": "openai/gpt-3.5-turbo"},
+        )
+        assert config.mcp_servers["test"]["url"] == "https://test.example.com"
+        assert config.litellm["model"] == "openai/gpt-3.5-turbo"
+        assert config.system_prompt is None  # デフォルトはNone
 
 
 class TestSystemPromptConfig:


### PR DESCRIPTION
## 概要

メイン設定クラスYgentsConfigにシステムプロンプト設定フィールドを追加しました。

## 実装内容

### YgentsConfigクラスの拡張
```python
class YgentsConfig(BaseModel):
    """Main ygents configuration."""

    mcp_servers: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
    litellm: Dict[str, Any] = Field(default_factory=dict)

    # システムプロンプト設定
    system_prompt: Optional[SystemPromptConfig] = Field(
        default=None, description="システムプロンプトの設定"
    )
```

### 主要な特徴

#### 1. Optional[SystemPromptConfig]フィールド
- **型**: `Optional[SystemPromptConfig]`
- **デフォルト**: `None`
- **目的**: 既存設定との互換性を完全に保持

#### 2. Pydantic自動型変換
- **dict → SystemPromptConfig**: 自動変換をサポート
- **型安全性**: Pydanticによる強力な型チェック
- **バリデーション**: フィールド定義に基づく自動検証

#### 3. 柔軟な設定形式
```python
# SystemPromptConfigオブジェクト
config = YgentsConfig(
    system_prompt=SystemPromptConfig(type="react")
)

# dict形式（自動変換される）
config = YgentsConfig(
    system_prompt={
        "type": "custom",
        "custom_prompt": "あなたは{role}です。",
        "variables": {"role": "エンジニア"}
    }
)
```

### 包括的テスト追加

4個の新規テストケース：
- `test_ygents_config_with_system_prompt`: SystemPromptConfigオブジェクト使用
- `test_ygents_config_with_system_prompt_dict`: dict形式での設定
- `test_ygents_config_full_configuration`: 全フィールド組み合わせ
- `test_ygents_config_backward_compatibility`: 既存設定の互換性確認

## テスト結果

```
14 passed in 0.61s (既存10個 + 新規4個)
型チェック: Success: no issues found
Lint: エラーなし
```

## 使用例

### 基本的な使用
```python
# システムプロンプトなし（従来通り）
config = YgentsConfig(
    litellm={"model": "openai/gpt-4o", "api_key": "key"}
)
# config.system_prompt is None

# ReActプロンプト使用
config = YgentsConfig(
    litellm={"model": "openai/gpt-4o", "api_key": "key"},
    system_prompt={"type": "react"}
)
```

### YAML設定での使用イメージ
```yaml
mcpServers:
  weather:
    url: "https://weather-api.example.com/mcp"

litellm:
  model: "openai/gpt-4o"
  api_key: "${OPENAI_API_KEY}"

# システムプロンプト設定
system_prompt:
  type: "react"
  variables:
    domain: "データ分析"
    expertise_level: "上級"
```

### プログラマティックな使用
```python
from ygents.config.models import YgentsConfig, SystemPromptConfig

# 完全な設定例
config = YgentsConfig(
    mcp_servers={"weather": {"url": "https://weather.example.com"}},
    litellm={"model": "openai/gpt-4o", "api_key": "your-key"},
    system_prompt={
        "type": "custom",
        "custom_prompt": "あなたは{role}として{task}を実行してください。",
        "variables": {
            "role": "データサイエンティスト",
            "task": "統計分析とレポート作成"
        }
    }
)
```

## 技術的特徴

1. **後方互換性**: 既存設定でsystem_prompt未指定時の動作は変更なし
2. **型安全性**: Pydanticによる強力な型チェックとバリデーション
3. **自動変換**: dict形式からSystemPromptConfigへの自動変換
4. **直感的設定**: JSONやYAMLでの設定が自然に記述可能

## 設計原則

1. **非破壊的変更**: 既存のYgentsConfig使用箇所への影響ゼロ
2. **段階的導入**: system_promptを使いたい場合のみ指定
3. **設定の簡潔性**: dict形式での直感的な設定をサポート
4. **拡張性**: 将来的なシステムプロンプト機能拡張に対応

## 依存関係

この実装により以下が可能になります：
- Issue #30: Agentクラスでのシステムプロンプト注入機能
- Issue #31: システムプロンプト取得と適用ロジック
- Issue #32: テンプレート変数システム

## 関連

- Closes #29
- Part of システムプロンプト管理機能の実装
- 依存: Issue #25, #26, #28 (完了済み)
- 設計書: `design/system-prompt-management.md`

🤖 Generated with [Claude Code](https://claude.ai/code)