### PR TITLE
docs: 設定読み込み時のプロンプトタイプ検証を設計書に追加

### DIFF
--- a/src/ygents/config/models.py
+++ b/src/ygents/config/models.py
@@ -30,3 +30,8 @@ class YgentsConfig(BaseModel):
 
     mcp_servers: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     litellm: Dict[str, Any] = Field(default_factory=dict)
+
+    # システムプロンプト設定
+    system_prompt: Optional[SystemPromptConfig] = Field(
+        default=None, description="システムプロンプトの設定"
+    )

--- a/tests/test_config/test_models.py
+++ b/tests/test_config/test_models.py
@@ -11,6 +11,7 @@ class TestYgentsConfig:
         config = YgentsConfig()
         assert config.mcp_servers == {}
         assert config.litellm == {}
+        assert config.system_prompt is None
 
     def test_ygents_config_with_litellm(self):
         """Test Ygents config with litellm configuration."""
@@ -38,6 +39,55 @@ class TestYgentsConfig:
         assert config.mcp_servers["weather"]["url"] == "https://weather.example.com"
         assert config.mcp_servers["assistant"]["command"] == "python"
         assert config.litellm["model"] == "claude-3-sonnet-20240229"
+
+    def test_ygents_config_with_system_prompt(self):
+        """Test YgentsConfig with system prompt configuration."""
+        system_prompt_config = SystemPromptConfig(type="react")
+        config = YgentsConfig(
+            litellm={"model": "openai/gpt-4o", "api_key": "test-key"},
+            system_prompt=system_prompt_config,
+        )
+        assert config.system_prompt is not None
+        assert config.system_prompt.type == "react"
+        assert config.system_prompt.custom_prompt is None
+        assert config.system_prompt.variables == {}
+
+    def test_ygents_config_with_system_prompt_dict(self):
+        """Test YgentsConfig with system prompt as dict."""
+        config = YgentsConfig(
+            system_prompt={
+                "type": "custom",
+                "custom_prompt": "あなたは{role}です。",
+                "variables": {"role": "エンジニア"},
+            }
+        )
+        assert config.system_prompt is not None
+        assert config.system_prompt.type == "custom"
+        assert config.system_prompt.custom_prompt == "あなたは{role}です。"
+        assert config.system_prompt.variables == {"role": "エンジニア"}
+
+    def test_ygents_config_full_configuration(self):
+        """Test YgentsConfig with all fields including system_prompt."""
+        config = YgentsConfig(
+            mcp_servers={"weather": {"url": "https://weather.example.com"}},
+            litellm={"model": "openai/gpt-4o", "api_key": "test-key"},
+            system_prompt={"type": "react", "variables": {"domain": "データ分析"}},
+        )
+        assert len(config.mcp_servers) == 1
+        assert config.litellm["model"] == "openai/gpt-4o"
+        assert config.system_prompt is not None
+        assert config.system_prompt.type == "react"
+        assert config.system_prompt.variables == {"domain": "データ分析"}
+
+    def test_ygents_config_backward_compatibility(self):
+        """Test that existing configurations without system_prompt still work."""
+        config = YgentsConfig(
+            mcp_servers={"test": {"url": "https://test.example.com"}},
+            litellm={"model": "openai/gpt-3.5-turbo"},
+        )
+        assert config.mcp_servers["test"]["url"] == "https://test.example.com"
+        assert config.litellm["model"] == "openai/gpt-3.5-turbo"
+        assert config.system_prompt is None  # デフォルトはNone
 
 
 class TestSystemPromptConfig:


### PR DESCRIPTION
## 概要

システムプロンプト管理機能の設計書を更新し、設定ファイル読み込み時のプロンプトタイプ検証機能に関する設計を追加しました。

## 変更内容

### 1. 設計目標の更新
- **早期検証**を新たな設計目標として追加
- 設定ファイル読み込み時にプロンプトタイプの妥当性を検証

### 2. アーキテクチャの追加
**新セクション**: 「3. 設定読み込み時の検証」

```python
class ConfigLoader:
    def _validate_system_prompt_config(self, config_dict: Dict[str, Any]) -> None:
        """システムプロンプト設定の検証"""
        # プロンプトタイプの検証
        prompt_type = system_prompt.get("type", "default")
        if prompt_type not in PROMPT_TEMPLATES:
            available_types = list(PROMPT_TEMPLATES.keys())
            raise ValueError(
                f"Invalid prompt type '{prompt_type}'. "
                f"Available types: {available_types}"
            )
```

### 3. 実装計画の更新
**新規項目**: 「5.5. ConfigLoaderでの設定検証機能を実装」
- `_validate_system_prompt_config`メソッド実装
- 設定ファイル読み込み時のプロンプトタイプ検証
- 存在しないプロンプトタイプの早期エラー検出

### 4. テスト戦略の拡張
- 設定読み込み時のプロンプトタイプ検証テストを追加

## 設計の意図

### 早期エラー検出
- 設定ファイル読み込み時に不正なプロンプトタイプを検出
- Agent初期化前にエラーを発見し、明確なエラーメッセージを提供

### 堅牢性の向上
- 存在しないプロンプトタイプの指定を防止
- 利用可能なプロンプトタイプのリストを表示

### 開発者体験の改善
```yaml
# 不正な設定例
system_prompt:
  type: "invalid_type"  # エラー: Invalid prompt type 'invalid_type'. Available types: ['default']
```

## 技術的考慮

1. **依存関係**: ConfigLoaderがPromptTemplateに依存
2. **循環依存回避**: 適切なモジュール構成で回避
3. **パフォーマンス**: 設定読み込み時の軽微なオーバーヘッド

## 今後の実装

この設計に基づいて以下を実装予定：
1. ConfigLoaderでの検証機能実装
2. 対応するテストケース追加
3. エラーメッセージの国際化対応

## 関連

- Part of システムプロンプト管理機能の実装
- 設計書: `design/system-prompt-management.md`
- 関連Issues: #25-#36

🤖 Generated with [Claude Code](https://claude.ai/code)